### PR TITLE
Bug Fixes: XML UnWrapping and retrieving words from the Lexicon.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="res"/>
+	<classpathentry kind="src" path="testsrc"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="lib/junit-4.4.jar"/>
+	<classpathentry kind="lib" path="lib/lexAccess2013dist.jar"/>
+	<classpathentry kind="lib" path="lib/lexCheck2006api.jar"/>
+	<classpathentry kind="lib" path="lib/lvg2011api.jar"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build
+bin
+*.class
+*.log
+

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>SimpleNLG</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/build.xml
+++ b/build.xml
@@ -32,7 +32,7 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
     <property name="classes.dir" value="${build.dir}/classes"/>
     <property name="jar.dir"     value="${build.dir}/jar"/>
     <property name="report.dir"  value="${build.dir}/junitreport"/>
-    <property name="lexicon.dir" value="lexicon" />
+    <property name="lexicon.dir" value="/Users/roman/NLP/Lexicons/lexAccess2013lite/data/HSqlDb" />
 
     <property name="main-class"  value="simplenlg.server.SimpleServer"/>
     
@@ -49,8 +49,9 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
     -->
     <!-- Selective Libraries included on the classpath -->
     <path id="classpath">
+        <!-- <pathelement path="${lib.dir}/jaxb-impl.jar" /> -->
         <pathelement path="${lib.dir}/junit-4.4.jar" />
-        <pathelement path="${lib.dir}/lexAccess2011dist.jar" />
+        <pathelement path="${lib.dir}/lexAccess2013dist.jar" />
         <pathelement path="${lib.dir}/lexCheck2006api.jar" />
         <pathelement path="${lib.dir}/lvg2011api.jar" />
     </path>
@@ -64,10 +65,10 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
     <!-- Compiles SimpleNLG and includes the lexicon.properties file -->
     <target name="compile">
         <mkdir dir="${classes.dir}"/>
-        <javac target="1.6" srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath">
-	   <!-- Someone is using internal Sun/Oracle classes... -->
-	   <compilerarg value="-XDignore.symbol.file" />
-	</javac>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath">
+            <!-- Someone is using internal Sun/Oracle classes... -->
+            <compilerarg value="-XDignore.symbol.file" />
+       </javac>
         <copy todir="${classes.dir}">
             <fileset dir="${res.dir}" includes="*.properties"/>
         </copy>
@@ -79,10 +80,10 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
     <!-- Compiles SimpleNLG without including the lexicon.properties file -->
     <target name="compile-noproperties">
         <mkdir dir="${classes.dir}"/>
-        <javac target="1.6" srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath">
-       <!-- Someone is using internal Sun/Oracle classes... -->
-       <compilerarg value="-XDignore.symbol.file" />
-    </javac>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath">
+            <!-- Someone is using internal Sun/Oracle classes... -->
+            <compilerarg value="-XDignore.symbol.file" />
+        </javac>
         <copy todir="${classes.dir}/simplenlg/lexicon">
             <fileset dir="${res.dir}" includes="default-lexicon.xml" />
         </copy>
@@ -91,7 +92,8 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
     <!-- Check to see if the code compiles -->
     <target name="compile.test" depends="compile">
         <mkdir dir="${classes.dir}"/>
-        <javac target="1.6" srcdir="${testsrc.dir}" destdir="${classes.dir}" classpathref="classpath"/>
+        <javac srcdir="${testsrc.dir}" destdir="${classes.dir}" classpathref="classpath">
+        </javac>
     </target>
 
     <!-- Builds a SimpleNLG Library JAR and bundles third-party libraries -->
@@ -106,7 +108,7 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
             <fileset dir="${classes.dir}" includes="**/*.class" />
             <fileset dir="${src.dir}" includes="**/*.java" />
             <zipgroupfileset dir="${lib.dir}" includes="**/*.jar">
-	        <exclude name="lexAccess2013dis.jar"/>
+	        <exclude name="jaxb-impl.jar"/>
             </zipgroupfileset>
         </jar>
     </target>
@@ -189,7 +191,9 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
             </classpath>
             
             <jvmarg line="-Xmx512m"/>
-            
+        	<env key="LexDBPath" value="${lexicon.dir}/lexAccess2013.data"/>
+            <env key="TestFilePath" value="${testsrc.dir}/simplenlg/xmlrealiser/"/>      
+        	                        
             <formatter type="xml"/>
             
             <batchtest todir="${report.dir}">
@@ -201,8 +205,8 @@ Contributor(s): Ehud Reiter, Albert Gatt, Dave Westwater, Roman Kutlak, Margaret
                         <exclude name="**/SimpleNLG4Test.*" />
                         <exclude name="**/StandAloneExample*" />
                         <exclude name="**/ClauseAggregationTest2*"/>
-                         <!-- XML Tests: Excluded as they require enviroment variables. -->
-                        <exclude name="**/Tester.*" /> 
+                	    <!-- XML Tests: Excluded as they require enviroment variables. -->
+                	    <!-- <exclude name="**/Tester.*" /> --> 
                 </fileset>
             </batchtest>
         </junit>

--- a/res/lexicon.properties
+++ b/res/lexicon.properties
@@ -2,7 +2,8 @@
 LexiconType=NIH
 
 # NIH lexicon path
-DB_FILENAME=C:\\Users\\saad.mahamood.D2T\\Documents\\ExternalSimpleNLG\\simplenlg\\lexicon\\lexAccess2011.data
+DB_FILENAME=/Users/roman/NLP/Lexicons/lexAccess2013lite/data/HSqlDb/lexAccess2013.data
 # default XML lexicon path
-XML_FILENAME=C:\\Users\\saad.mahamood.D2T\\Documents\\ExternalSimpleNLG\\simplenlg\\res\\default-lexicon.xml
+XML_FILENAME=/Users/roman/NLP/Lexicons/default/default-lexicon.xml
+
 

--- a/src/simplenlg/lexicon/Lexicon.java
+++ b/src/simplenlg/lexicon/Lexicon.java
@@ -226,8 +226,13 @@ public abstract class Lexicon {
 			if (wordElement.getBaseForm().equals(baseForm))
 				return wordElement;
 		
+		// Roman Kutlak: I don't think it is a good idea to return a word whose
+		// case does not match because if a word appears in the lexicon
+		// as an acronym only, it will be replaced as such. For example,
+		// "foo" will return as the acronym "FOO". This does not seem desirable.
 		// else return first element in list
-		return wordElements.get(0);
+//		return wordElements.get(0);
+		return createWord(baseForm, LexicalCategory.ANY);
 	}
 
 	/**
@@ -396,7 +401,7 @@ public abstract class Lexicon {
 		// using variant as base
 		// form
 		else
-			return wordElements.get(0); // else return first match
+			return selectMatchingWord(wordElements, variant);
 
 	}
 

--- a/src/simplenlg/orthography/english/OrthographyProcessor.java
+++ b/src/simplenlg/orthography/english/OrthographyProcessor.java
@@ -293,8 +293,12 @@ public class OrthographyProcessor extends NLGModule {
 	 *            sentence is an interrogative, <code>false</code> otherwise.
 	 */
 	private void terminateSentence(StringBuffer realisation, boolean interrogative) {
-		char character = realisation.charAt(realisation.length() - 2);
-		if(character != '.' && character != '?') {
+	    if (realisation.length() == 0) {
+	        return;
+	    }
+		char character = realisation.charAt(realisation.length() - 1);
+		if(character != '.' && character != '?' &&
+		        character != ';' && character != '!') {
 			if(interrogative) {
 				realisation.append('?');
 			} else {

--- a/src/simplenlg/server/RealisationRequest.java
+++ b/src/simplenlg/server/RealisationRequest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.Socket;
+import java.net.URLDecoder;
 
 import simplenlg.xmlrealiser.XMLRealiser;
 import simplenlg.xmlrealiser.XMLRealiserException;
@@ -85,9 +86,12 @@ public class RealisationRequest implements Runnable {
             } 
             
             // now convert the raw bytes to utf-8
-            String tmp = new String(data, "UTF-8");
-            StringReader reader = new StringReader(tmp);
-            
+            String tmp = URLDecoder.decode(new String(data, "UTF-8"), "UTF-8");
+            StringReader reader = new StringReader(tmp.trim());
+            if (DEBUG) {
+                String text = "Client sent the following data:";
+                System.out.println(text + "\n\t" + tmp);
+            }
             // get the realisation
             String result = doRealisation(reader).trim();
             
@@ -104,15 +108,6 @@ public class RealisationRequest implements Runnable {
                 System.out.println(text + "\n\t" + result);
             }
             
-        } catch (Exception e) {
-            e.printStackTrace();
-            try {
-                // attempt to send the error message to the client
-                byte[] tmp = ("Exception: " + e.getMessage()).getBytes("UTF-8");
-                output.writeInt(tmp.length);
-                output.write(tmp);
-            } catch (IOException e1) {
-            }
         } catch (XMLRealiserException e) {
             e.printStackTrace();
             try {
@@ -121,6 +116,17 @@ public class RealisationRequest implements Runnable {
                 output.writeInt(tmp.length);
                 output.write(tmp);
             } catch (IOException e1) {
+                e1.printStackTrace(System.err);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            try {
+                // attempt to send the error message to the client
+                byte[] tmp = ("Exception: " + e.getMessage()).getBytes("UTF-8");
+                output.writeInt(tmp.length);
+                output.write(tmp);
+            } catch (IOException e1) {
+                e1.printStackTrace(System.err);
             }
         } finally {
             try {

--- a/src/simplenlg/server/SimpleServer.java
+++ b/src/simplenlg/server/SimpleServer.java
@@ -57,7 +57,7 @@ public class SimpleServer implements Runnable {
     /**
      * Set to true to enable printing debug messages.
      */
-    static boolean DEBUG = false;
+    static boolean DEBUG = true;
     
     /**
      * This path should be replaced by the path to the specialist lexicon.
@@ -65,7 +65,7 @@ public class SimpleServer implements Runnable {
      * will be searched for the lexicon file. Otherwise, the path below will
      * be used.
      */
-    String lexiconPath = "/tmp/lexAccess2011lite/data/HSqlDb/lexAccess2011.data";
+    String lexiconPath = "";
 
     // control the run loop
     private boolean isActive = true;
@@ -118,9 +118,12 @@ public class SimpleServer implements Runnable {
             else
                 throw new Exception("No DB_FILENAME in lexicon.properties");
         } catch (Exception e) {
+            System.err.println("Server could not find the lexicon.properties file.");
             e.printStackTrace();
         }
         
+        if (lexiconPath.equals(""))
+            throw new IOException("No lexicon found.");
         System.out.println("Server is using the following lexicon: "
                            + lexiconPath);
         
@@ -236,13 +239,16 @@ public class SimpleServer implements Runnable {
      *          Program arguments
      */
     public static void main(String[] args) {
-        int port;
-        try {
-            port = Integer.parseInt(args[0]);
-        } catch (Exception e) {
-            port = 50007;
+        int port = 50007;
+        if (args.length > 0) {
+            try {
+                port = Integer.parseInt(args[0]);
+            } catch (Exception e) {
+                System.err.println("Server could not parse the server port: '" + args[0] + "'");
+                port = 50007;
+            }
         }
-
+        
         try {
             SimpleServer serverapp = new SimpleServer(port);
 
@@ -260,7 +266,8 @@ public class SimpleServer implements Runnable {
                     bw.flush();
                     String input = br.readLine();
 
-                    if (null != input && input.compareToIgnoreCase("exit") == 0) {
+                    if (null != input && 
+                            input.trim().compareToIgnoreCase("exit") == 0) {
                         serverapp.shutdown();
                         serverapp.exit();
                     }

--- a/src/simplenlg/xmlrealiser/UnWrapper.java
+++ b/src/simplenlg/xmlrealiser/UnWrapper.java
@@ -729,6 +729,12 @@ public class UnWrapper {
 				Feature.PROGRESSIVE).booleanValue();
 		sp.setFeature(Feature.PROGRESSIVE, sProg || vProg);
 
+		// perfect: can be set on S or VP
+		boolean sPerf = wp.isPERFECT() == null ? false : wp.isPERFECT();
+		boolean vPerf = vp == null ? false : vp.getFeatureAsBoolean(
+				Feature.PERFECT).booleanValue();
+		sp.setFeature(Feature.PERFECT, sPerf || vPerf);
+
 		// negation: can be set on S or VP
 		boolean sNeg = wp.isNEGATED() == null ? false : wp.isNEGATED();
 		boolean vNeg = vp == null ? false : vp.getFeatureAsBoolean(


### PR DESCRIPTION
The first par is just an oversight -- the XML UnWrapper was missing a check for the feature "PERFECT". If you set it in the XML request, it was ignored.

The second fix is a bit more contentious. One can say that it is a feature rather than bug. When you retrieve a word from the lexicon, it can accidentally match acronyms. For example, the string "foo" would come realised as "FOO" because the NIH lexicon has an acronym "FOO" and searching for a word in the lexicon is case in-sensitive. I don't think this is desirable behaviour so instead of returning the first case in-sensitive match, I create a new word and return that.