### PR TITLE
Xml fix

### DIFF
--- a/src/simplenlg/lexicon/Lexicon.java
+++ b/src/simplenlg/lexicon/Lexicon.java
@@ -226,8 +226,13 @@ public abstract class Lexicon {
 			if (wordElement.getBaseForm().equals(baseForm))
 				return wordElement;
 		
+		// Roman Kutlak: I don't think it is a good idea to return a word whose
+		// case does not match because if a word appears in the lexicon
+		// as an acronym only, it will be replaced as such. For example,
+		// "foo" will return as the acronym "FOO". This does not seem desirable.
 		// else return first element in list
-		return wordElements.get(0);
+//		return wordElements.get(0);
+		return createWord(baseForm, LexicalCategory.ANY);
 	}
 
 	/**
@@ -396,7 +401,7 @@ public abstract class Lexicon {
 		// using variant as base
 		// form
 		else
-			return wordElements.get(0); // else return first match
+			return selectMatchingWord(wordElements, variant);
 
 	}
 

--- a/src/simplenlg/xmlrealiser/UnWrapper.java
+++ b/src/simplenlg/xmlrealiser/UnWrapper.java
@@ -729,6 +729,12 @@ public class UnWrapper {
 				Feature.PROGRESSIVE).booleanValue();
 		sp.setFeature(Feature.PROGRESSIVE, sProg || vProg);
 
+		// perfect: can be set on S or VP
+		boolean sPerf = wp.isPERFECT() == null ? false : wp.isPERFECT();
+		boolean vPerf = vp == null ? false : vp.getFeatureAsBoolean(
+				Feature.PERFECT).booleanValue();
+		sp.setFeature(Feature.PERFECT, sPerf || vPerf);
+
 		// negation: can be set on S or VP
 		boolean sNeg = wp.isNEGATED() == null ? false : wp.isNEGATED();
 		boolean vNeg = vp == null ? false : vp.getFeatureAsBoolean(


### PR DESCRIPTION
The XML UnWrapper was missing a check for the feature "PERFECT". When you set it in the XML request, it was ignored.

Retrieving a word from the lexicon was changed to case-sensitive retrieval.