### PR TITLE
Various comma fixes: 

### DIFF
--- a/src/main/java/simplenlg/features/Feature.java
+++ b/src/main/java/simplenlg/features/Feature.java
@@ -205,7 +205,7 @@ abstract public class Feature {
 	 * </tr>
 	 * </table>
 	 */
-	public static String COMPLEMENTISER = "complementiser";
+	public static final String COMPLEMENTISER = "complementiser";
 
 	/**
 	 * <p>

--- a/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
+++ b/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
@@ -166,8 +166,20 @@ public class OrthographyProcessor extends NLGModule {
 				StringBuffer buffer = new StringBuffer();
 
 				if(DiscourseFunction.PRE_MODIFIER.equals(function)) {
-					realiseList(buffer, element.getChildren(), this.commaSepPremodifiers ? "," : "");
 
+					boolean all_appositives = true;
+					for(NLGElement child : element.getChildren()){
+						all_appositives = all_appositives && child.getFeatureAsBoolean(Feature.APPOSITIVE);
+					}
+
+					// TODO: unless this is the end of the sentence
+					if(all_appositives){
+						buffer.append(", ");
+					}
+					realiseList(buffer, element.getChildren(), this.commaSepPremodifiers ? "," : "");
+					if(all_appositives){
+						buffer.append(", ");
+					}
 				} else if(DiscourseFunction.POST_MODIFIER.equals(function)) {// &&
 					                                                         // appositive)
 					                                                         // {
@@ -272,6 +284,7 @@ public class OrthographyProcessor extends NLGModule {
 			StringBuffer realisation = new StringBuffer();
 			realiseList(realisation, components, "");
 
+			stripLeadingCommas(realisation);
 			capitaliseFirstLetter(realisation);
 			terminateSentence(realisation, element.getFeatureAsBoolean(InternalFeature.INTERROGATIVE).booleanValue());
 
@@ -305,6 +318,23 @@ public class OrthographyProcessor extends NLGModule {
 			}
 		}
 	}
+
+	/**
+	 * Remove recursively any leading spaces or commas at the start 
+	 * of a sentence.
+	 * 
+	 * @param realisation
+	 *            the <code>StringBuffer<code> containing the current 
+	 * realisation of the sentence.
+	 */
+	private void stripLeadingCommas(StringBuffer realisation) {
+		char character = realisation.charAt(0);
+		if(character == ' ' || character == ',') {
+			realisation.deleteCharAt(0);
+			stripLeadingCommas(realisation);
+		}
+	}
+
 
 	/**
 	 * Capitalises the first character of a sentence if it is a lower case

--- a/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
+++ b/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
@@ -209,6 +209,10 @@ public class OrthographyProcessor extends NLGModule {
 						}
 					}
 
+				} else if((DiscourseFunction.CUE_PHRASE.equals(function) || DiscourseFunction.FRONT_MODIFIER.equals(function))
+			   && this.commaSepCuephrase){
+					realiseList(buffer, element.getChildren(), this.commaSepCuephrase ? "," : "");
+
 				} else {
 					realiseList(buffer, element.getChildren(), "");
 				}
@@ -218,7 +222,6 @@ public class OrthographyProcessor extends NLGModule {
 
 			} else if(element instanceof CoordinatedPhraseElement) {
 				realisedElement = realiseCoordinatedPhrase(element.getChildren());
-
 			} else {
 				realisedElement = element;
 			}

--- a/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
+++ b/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
@@ -263,6 +263,7 @@ public class OrthographyProcessor extends NLGModule {
 
 			if(realisation != null) {
 				realisation = realisation.replaceAll(" ,", ",");
+				realisation = realisation.replaceAll(",,+", ",");
 				realisedElement.setRealisation(realisation);
 			}
 

--- a/src/test/java/simplenlg/syntax/english/OrthographyFormatTests.java
+++ b/src/test/java/simplenlg/syntax/english/OrthographyFormatTests.java
@@ -30,6 +30,11 @@ import org.junit.Test;
 import simplenlg.format.english.TextFormatter;
 import simplenlg.framework.DocumentElement;
 import simplenlg.framework.NLGElement;
+import simplenlg.phrasespec.NPPhraseSpec;
+import simplenlg.phrasespec.PPPhraseSpec;
+import simplenlg.phrasespec.SPhraseSpec;
+import simplenlg.features.Feature;
+import simplenlg.features.NumberAgreement;
 
 public class OrthographyFormatTests extends SimpleNLG4Test {
 
@@ -96,5 +101,106 @@ public class OrthographyFormatTests extends SimpleNLG4Test {
 		NLGElement realised = this.realiser.realise(this.list2);
 		Assert.assertEquals(this.list2Realisation, realised.getRealisation());
 	}
+
+	/**
+	 * Test the realisation of appositive pre-modifiers with commas around them.
+	 */
+	@Test
+	public void testAppositivePreModifiers() {
+		NPPhraseSpec subject = this.phraseFactory.createNounPhrase("I");
+		NPPhraseSpec object = this.phraseFactory.createNounPhrase("a bag");
+
+		SPhraseSpec _s1 = this.phraseFactory.createClause(subject,
+				"carry", object);
+
+		// add a PP complement
+		PPPhraseSpec pp = this.phraseFactory.createPrepositionPhrase("on",
+				this.phraseFactory.createNounPhrase("most", "Tuesdays"));
+		_s1.addPreModifier(pp);
+		
+		//without appositive feature on pp
+		Assert.assertEquals(
+				"I on most Tuesdays carry a bag", this.realiser
+						.realise(_s1).getRealisation());
+		
+		//with appositive feature
+		pp.setFeature(Feature.APPOSITIVE, true);
+		Assert.assertEquals(
+				"I, on most Tuesdays, carry a bag", this.realiser
+						.realise(_s1).getRealisation());
+	}
+
+
+	/**
+	 * Test the realisation of appositive pre-modifiers with commas around them.
+	 */
+	@Test
+	public void testCommaSeparatedFrontModifiers() {
+		NPPhraseSpec subject = this.phraseFactory.createNounPhrase("I");
+		NPPhraseSpec object = this.phraseFactory.createNounPhrase("a bag");
+
+		SPhraseSpec _s1 = this.phraseFactory.createClause(subject,
+				"carry", object);
+
+		// add a PP complement
+		PPPhraseSpec pp1 = this.phraseFactory.createPrepositionPhrase("on",
+				this.phraseFactory.createNounPhrase("most", "Tuesdays"));
+		_s1.addFrontModifier(pp1);
+
+		PPPhraseSpec pp2 = this.phraseFactory.createPrepositionPhrase("since",
+				this.phraseFactory.createNounPhrase("1991"));
+		_s1.addFrontModifier(pp2);
+		pp1.setFeature(Feature.APPOSITIVE, true);
+		pp2.setFeature(Feature.APPOSITIVE, true);
+
+		//without setCommaSepCuephrase
+		Assert.assertEquals(
+				"on most Tuesdays since 1991 I carry a bag", this.realiser
+						.realise(_s1).getRealisation());
+		
+		//with setCommaSepCuephrase
+		this.realiser.setCommaSepCuephrase(true);
+		Assert.assertEquals(
+				"on most Tuesdays, since 1991, I carry a bag", this.realiser
+						.realise(_s1).getRealisation());
+	}
+
+	/**
+	 * Ensure we don't end up with doubled commas.
+	 */
+	@Test
+	public void testNoDoubledCommas() {
+		NPPhraseSpec subject = this.phraseFactory.createNounPhrase("I");
+		NPPhraseSpec object = this.phraseFactory.createNounPhrase("a bag");
+
+		SPhraseSpec _s1 = this.phraseFactory.createClause(subject,
+				"carry", object);
+
+		PPPhraseSpec pp1 = this.phraseFactory.createPrepositionPhrase("on",
+				this.phraseFactory.createNounPhrase("most", "Tuesdays"));
+		_s1.addFrontModifier(pp1);
+
+		PPPhraseSpec pp2 = this.phraseFactory.createPrepositionPhrase("since",
+				this.phraseFactory.createNounPhrase("1991"));
+		PPPhraseSpec pp3 = this.phraseFactory.createPrepositionPhrase("except",
+				this.phraseFactory.createNounPhrase("yesterday"));
+
+		pp2.setFeature(Feature.APPOSITIVE, true);
+		pp3.setFeature(Feature.APPOSITIVE, true);
+
+		pp1.addPostModifier(pp2);
+		pp1.addPostModifier(pp3);
+
+		this.realiser.setCommaSepCuephrase(true);
+		
+		Assert.assertEquals(
+				"on most Tuesdays, since 1991, except yesterday, I carry a bag", this.realiser
+						.realise(_s1).getRealisation());
+		// without my fix (that we're testing here), you'd end up with 
+		// "on most Tuesdays, since 1991,, except yesterday, I carry a bag"
+	}
+
+// <[on most Tuesdays, since 1991, except yesterday, ]I carry a bag> but was:<[]I carry a bag>
+
 
 }


### PR DESCRIPTION
As described in #15, I've made a handful of fixes to address some issues with commas in sentences with a bunch of prepositional phrases as pre/front modifiers.

I've made a handful of modifications:

> to add commas around appositive pre-modifiers: 6abc16a
> to comma-separate all cue phrases and front modifiers, if commaSepcuephrase is set: jeremybmerrill@5d1252e
> and to make the COMPLEMENTISER feature final, which I think is necessary to allow it to be set (at least in JRuby): 3eed77f

Per @Saad-Mahamood's request, I've added tests. The tests pass (both mine and the default tests that run with `mvn test`*). Let me know if there's any questions or concerns and, as always, thanks for the awesome library!

\* Strangely, my tests, in `OrthographyFormatTests.java` don't seem to be run with `mvn test`. I don't know much about Maven or Java tooling generally, but I was able to get mine to run (and pass) with `mvn -Dtest=OrthographyFormatTests test`.

This would close #15 if accepted.