### PR TITLE
don't change possessor's number to match possessed noun

### DIFF
--- a/src/main/java/simplenlg/syntax/english/NounPhraseHelper.java
+++ b/src/main/java/simplenlg/syntax/english/NounPhraseHelper.java
@@ -174,8 +174,7 @@ abstract class NounPhraseHelper {
 		if (specifierElement != null
 				&& !phrase.getFeatureAsBoolean(InternalFeature.RAISED)
 						.booleanValue() && !phrase.getFeatureAsBoolean(Feature.ELIDED).booleanValue()) {
-
-			if (!specifierElement.isA(LexicalCategory.PRONOUN)) {
+			if (!specifierElement.isA(LexicalCategory.PRONOUN) && specifierElement.getCategory() != PhraseCategory.NOUN_PHRASE) {
 				specifierElement.setFeature(Feature.NUMBER, phrase
 						.getFeature(Feature.NUMBER));
 			}

--- a/src/test/java/simplenlg/syntax/english/NounPhraseTest.java
+++ b/src/test/java/simplenlg/syntax/english/NounPhraseTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import simplenlg.features.DiscourseFunction;
 import simplenlg.features.Feature;
+import simplenlg.features.Tense;
 import simplenlg.features.Gender;
 import simplenlg.features.InternalFeature;
 import simplenlg.features.LexicalFeature;
@@ -566,7 +567,41 @@ public class NounPhraseTest extends SimpleNLG4Test {
 				cat).getRealisation());
 
 	}
-	
+	 @Test
+  public void testPluralNounsBelongingToASingular() {
+
+    SPhraseSpec sent = this.phraseFactory.createClause("I", "count up");
+    sent.setFeature(Feature.TENSE, Tense.PAST);
+    NPPhraseSpec obj = this.phraseFactory.createNounPhrase("digit"); 
+    obj.setPlural(true);
+    NPPhraseSpec possessor = this.phraseFactory.createNounPhrase("the", "box");
+    possessor.setPlural(false);
+    possessor.setFeature(Feature.POSSESSIVE, true);
+    obj.setSpecifier(possessor);
+    sent.setObject(obj);
+
+    Assert.assertEquals("I counted up the box's digits", this.realiser.realise(sent) //$NON-NLS-1$
+        .getRealisation());
+  }
+
+
+	 @Test
+  public void testSingularNounsBelongingToAPlural() {
+
+    SPhraseSpec sent = this.phraseFactory.createClause("I", "clean");
+    sent.setFeature(Feature.TENSE, Tense.PAST);
+    NPPhraseSpec obj = this.phraseFactory.createNounPhrase("car"); 
+    obj.setPlural(false);
+    NPPhraseSpec possessor = this.phraseFactory.createNounPhrase("the", "parent");
+    possessor.setPlural(true);
+    possessor.setFeature(Feature.POSSESSIVE, true);
+    obj.setSpecifier(possessor);
+    sent.setObject(obj);
+
+    Assert.assertEquals("I cleaned the parents' car", this.realiser.realise(sent) //$NON-NLS-1$
+        .getRealisation());
+  }
+
 	/**
 	 * Test for appositive postmodifiers
 	 */


### PR DESCRIPTION
Due to what I assume is a bug, when a noun phrase possesses another noun, the head noun's features are carried over to the specifier (the possessor). Because of this bug, you can't generate a sentence like `the parents' car`, because the `Number.SINGULAR` feature on `car` gets carried over to `parents`, so the realization is `the parent's car`. Likewise, `the box's digits` is realized as `the boxes' digits` because the specifier, `digits`'s, Number.PLURAL feature is carried over to `box`.

This PR includes tests (failing without the PR, passing with it) and a fix to not carry over features if the SpecNP's PhraseCategory is a Noun Phrase. *This might not be the right rule.* But all the tests pass, so I don't think it's going to cause additional problems. (We may have to come back to it later, if this same bug occurs for other phrase categories.)

Let me know if you have questions or concerns.