### PR TITLE
Added "this"/"that" modifier support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target
+.idea
+SimpleNLG.iml
+lexAccess2011.data

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
 	<groupId>uk.ac.abdn</groupId>
 	<artifactId>SimpleNLG</artifactId>
-	<version>4.4.9-SNAPSHOT</version>
+	<version>4.4.9-FEDS</version>
 	<packaging>jar</packaging>
 	
   	<name>SimpleNLG</name>

--- a/src/main/java/simplenlg/morphology/english/MorphologyRules.java
+++ b/src/main/java/simplenlg/morphology/english/MorphologyRules.java
@@ -927,7 +927,25 @@ public abstract class MorphologyRules {
 				
 				}
 			}
-		
+
+			if (determiner.getRealisation().equals("this")) { //$NON-NLS-1$
+
+				if (determiner.isPlural()) {
+
+					determiner.setRealisation("these"); //$NON-NLS-1$
+
+				}
+			}
+
+			if (determiner.getRealisation().equals("that")) { //$NON-NLS-1$
+
+				if (determiner.isPlural()) {
+
+					determiner.setRealisation("those"); //$NON-NLS-1$
+
+				}
+			}
+
 //		if(determiner.getRealisation().equals("an") && !DeterminerAgrHelper.requiresAn(realisation)){
 //			
 //			determiner.setRealisation("a");


### PR DESCRIPTION
When choosing "this" or "that" as a modifier in a noun phrase, the framework should be able to adjust the modifier for plural, as it does for "a" => "some"