### PR TITLE
add plugin to pom.xml to disable doclint in java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,23 @@
 			        </execution>
 		      	</executions>
     		</plugin> -->
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 		<pluginManagement>
 			<plugins>
 				<plugin>


### PR DESCRIPTION
Turns off DocLint which becomes enabled by default in Java 8.

relevant stackoverflow: http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete