### PR TITLE
fixed two minor bugs in simpleNLG (probably copy-paste errors)

### DIFF
--- a/src/main/java/simplenlg/framework/LexicalCategory.java
+++ b/src/main/java/simplenlg/framework/LexicalCategory.java
@@ -88,7 +88,7 @@ public enum LexicalCategory implements ElementCategory {
 		boolean match = false;
 
 		if (checkObject != null) {
-			if (checkObject instanceof DocumentCategory) {
+			if (checkObject instanceof LexicalCategory) {
 				match = this.equals(checkObject);
 			} else {
 				match = this.toString()

--- a/src/main/java/simplenlg/framework/PhraseCategory.java
+++ b/src/main/java/simplenlg/framework/PhraseCategory.java
@@ -73,7 +73,7 @@ public enum PhraseCategory implements ElementCategory {
 		boolean match = false;
 
 		if (checkObject != null) {
-			if (checkObject instanceof DocumentCategory) {
+			if (checkObject instanceof PhraseCategory) {
 				match = this.equals(checkObject);
 			} else {
 				match = this.toString()


### PR DESCRIPTION
Hello,

I found two small bugs w.r.t. type checking of the object in the equalTo method in LexicalCategory and PhraseCategory. They seem to have been copied from DocumentCategory.

Kind regards,

Gert-Jan de Vries