### PR TITLE
Remove maven-antrun-plugin from compile deps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
             <version>2013</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
             <version>2013</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.8</version>
-        </dependency>
-        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>


### PR DESCRIPTION
This pulls in a bunch of other dependencies that are not needed.

Specifically, plexus-utils conflicts with kie deps in my case.